### PR TITLE
fstab: make encryptable instead of forcing encryption

### DIFF
--- a/rootdir/etc/fstab.qcom
+++ b/rootdir/etc/fstab.qcom
@@ -8,8 +8,8 @@
 
 /dev/block/bootdevice/by-name/system		/system			ext4	ro								wait,recoveryonly
 /dev/block/bootdevice/by-name/vendor		/vendor			ext4	ro								wait,recoveryonly
-/dev/block/bootdevice/by-name/userdata		/data			f2fs	nosuid,nodev,noatime,discard,fsync_mode=nobarrier		wait,check,quota,fileencryption=ice,reservedsize=128M
-/dev/block/bootdevice/by-name/userdata		/data			ext4	nosuid,nodev,noatime,noauto_da_alloc				wait,check,quota,formattable,fileencryption=ice,reservedsize=128M
+/dev/block/bootdevice/by-name/userdata		/data			f2fs	nosuid,nodev,noatime,discard,fsync_mode=nobarrier		wait,check,quota,encryptable=ice,reservedsize=128M
+/dev/block/bootdevice/by-name/userdata		/data			ext4	nosuid,nodev,noatime,noauto_da_alloc				wait,check,quota,formattable,encryptable=ice,reservedsize=128M
 /dev/block/bootdevice/by-name/cache		/cache			f2fs	nosuid,nodev,noatime,inline_xattr,flush_merge,data_flush	wait,formattable,check
 /dev/block/bootdevice/by-name/cache		/cache			ext4	nosuid,nodev,noatime						wait,formattable,check
 /dev/block/bootdevice/by-name/persist		/mnt/vendor/persist		ext4	nosuid,nodev,noatime						wait,check


### PR DESCRIPTION
This device originally uses FDE
For some reason this device isnt making ice encryption

W vold    : [libfs_mgr]Warning: unknown flag: =ice
Maybe it needs v2 of ICE encryption on CAF